### PR TITLE
chore: add `cooldown` to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    # Wait 14 days before updating to help circumvent supply chain attacks
+    cooldown:
+      default-days: 14
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
This PR will add a cooldown for 14 days to dependabot, to circumvent supply chain attacks.